### PR TITLE
docs: refresh CLAUDE.md, add AGENTS.md, and correct stale README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS.md
+
+## Commands
+- Runtime versions: Ruby (`.ruby-version`), Rails (`Gemfile`), Node (`.node-version`). Uses Yarn Classic (`yarn.lock`) — do not introduce npm lockfiles.
+- Install/update Ruby deps with `bundle install`; install JS deps with `yarn install --frozen-lockfile` when matching Docker/CI behavior.
+- `bin/setup --skip-server` runs bundle install if needed, `bin/rails db:prepare`, and clears logs/tmp; it does not install JS dependencies.
+- `bin/dev` only execs `bin/rails server`; it does not run the Vite server. For local UI work run Rails (`bin/rails server -p 3000`) and Vite (`yarn dev` or `bin/vite dev`, port `3036`) separately, or use `Procfile.dev` with an external process manager.
+- Build Vite assets with `yarn build` or `bin/vite build`; full Rails asset build is `bundle exec rake assets:precompile`.
+- JS lint is `yarn standard` (StandardJS). Ruby/ERB checks are `bin/rubocop` and `bundle exec erb_lint`; security checks are `bin/brakeman` and `bin/bundler-audit`.
+- Do not assume `bin/ci` is a green all-check command: `config/ci.rb` calls `bin/importmap audit`, but this Vite app has no `bin/importmap`.
+- There is currently no `test/` or `spec/` directory; verify changes with focused lint/build/boot checks unless you add tests.
+
+## App Shape
+- This is a Rails app for a reusable UI component library, not a packaged gem. Main public pages are documentation and examples under explicit routes in `config/routes.rb` (`/ui`, `/ui/*`, `/ui/form_builders/*`, `/ui/kit/*`) plus the theme builder at `/builder`.
+- SQLite databases live under `storage/*.sqlite3`; `config/database.yml` is the source of truth.
+- Production deploy is Kamal via `.github/workflows/01.deploy_production.yaml` and `config/deploy.yml`; image build uses `asset_path: /rails/public/vite/assets` and secrets `RAILS_MASTER_KEY`, `KAMAL_REGISTRY_USERNAME`, `KAMAL_REGISTRY_PASSWORD`.
+
+## Components And Docs
+- UI components live in `app/components/ui/<name>/`; main classes are `Ui::<Name>::Component`, and slot/subcomponents are nested `*Component` classes in the same folder.
+- Components render through the `ui` helper (`app/helpers/ui_helper.rb`), which resolves helper names by constantizing `Ui::<helper.camelize>::Component` first, then nested component names. Match helper names to class paths, e.g. `ui.turbo_confirm` -> `Ui::TurboConfirm::Component`, `ui.card_header` -> `Ui::Card::HeaderComponent`.
+- Component JS/CSS inside `app/components/**/*.js` and `app/components/**/*.css` is auto-imported by `app/assets/entrypoints/application.js`; put component-specific assets beside the component instead of adding manual imports.
+- Documentation pages are not generated from routes automatically. Adding a documented component usually needs the component folder, `component.yml`, an explicit route/controller action, and an `app/views/ui/*.html.erb` page that calls `render_component_*` helpers.
+- `component.yml` examples/previews are rendered as inline ERB by `ComponentDocsHelper`; keep snippets executable, not pseudocode. Form-builder docs are loaded from `app/components/form_builders/<name>/component.yml` even though their Ruby code lives under `app/lib/form_builders`.
+
+## Frontend Gotchas
+- Vite source root is `app/assets` (`config/vite.json`); existing JS imports use the `~` alias for paths under `app/assets`.
+- Tailwind CSS 4 is configured in CSS, not `tailwind.config.js`: see `app/assets/entrypoints/tailwind.css`, `app/assets/stylesheets/tailwind/*`, and `tailwindcss_safelist.txt`.
+- Stimulus controllers under `app/assets/controllers/**/*_controller.js` and component controllers are imported eagerly, but controllers register themselves with `stimulus.register(...)`; follow that pattern.
+- `ApplicationHelper#form_with` sets the default `form` class and `FormBuilders::DefaultFormBuilder`; custom form fields are in `app/lib/form_builders/fields`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,215 +2,77 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Development Commands
+## Sources of truth
 
-### Build and Development
-- `npm run dev` - Start the Vite development server
-- `npm run build` - Build assets for production
-- `npm run standard` - Run JavaScript StandardJS linting
+Check these files for the exact runtime versions:
 
-### Rails Commands
-- `bin/rails server` - Start Rails development server
-- `bin/rails console` - Open Rails console
-- `bin/vite dev` - Start Vite dev server (alternative to npm run dev)
-- `bin/vite build` - Build Vite assets (alternative to npm run build)
+- Ruby: `.ruby-version`
+- Rails: `Gemfile` (`gem "rails"` line), `config/application.rb` (`config.load_defaults`)
+- Node: `.node-version`
+- JS deps and scripts: `package.json` (Yarn Classic — `yarn.lock` is the lockfile, do not introduce npm lockfiles)
 
-### Quality Assurance
-- `bundle exec rubocop` - Run Ruby code style checks
-- `bundle exec brakeman` - Run security analysis
-- `bundle exec bundler-audit` - Check for vulnerable dependencies
-- `bundle exec erb_lint` - Lint ERB templates
+## What this app actually is
 
-## Architecture Overview
+A Rails app that hosts a reusable UI component library and its documentation site (it is **not** a packaged gem). Public pages are component docs and examples under explicit routes in `config/routes.rb` (`/ui`, `/ui/*`, `/ui/form_builders/*`, `/ui/kit/*`) plus a theme builder at `/builder`. SQLite databases live under `storage/*.sqlite3`; `config/database.yml` is the source of truth.
 
-This is a Rails 7 application using ViewComponent for component-based UI architecture. The frontend is built with Vite, TailwindCSS, and Stimulus.
+## Commands
 
-### Key Technologies
-- **Rails 7.0.8** - Backend framework
-- **ViewComponent** - Component-based view layer
-- **Vite** - Frontend build tool and dev server
-- **TailwindCSS 4.0** - Utility-first CSS framework
-- **Stimulus** - JavaScript framework for Rails
-- **Turbo** - SPA-like page acceleration
-- **Rodauth** - Authentication system
+- `bundle install` — Ruby deps. `yarn install --frozen-lockfile` — JS deps (matches Docker/CI).
+- `bin/setup --skip-server` — runs bundle install if needed, `bin/rails db:prepare`, clears logs/tmp. Does **not** install JS deps.
+- `bin/dev` — only execs `bin/rails server` (it does **not** also start Vite). For local UI work, run Rails (`bin/rails server -p 3000`) and Vite (`yarn dev` or `bin/vite dev`, port `3036`) in separate terminals, or use `Procfile.dev` with an external process manager.
+- `yarn build` / `bin/vite build` — build Vite assets. `bundle exec rake assets:precompile` — full Rails asset build.
+- Lint/security: `yarn standard` (StandardJS), `bin/rubocop` (Rails Omakase), `bundle exec erb_lint`, `bin/brakeman`, `bin/bundler-audit`.
+- Do **not** assume `bin/ci` is a green all-check command: `config/ci.rb` calls `bin/importmap audit`, but this Vite app has no `bin/importmap`.
+- There is currently **no `test/` or `spec/` directory**. Verify changes with focused lint/build/boot checks unless you add tests.
 
-### Component System
-The UI is built using a comprehensive component library located in `app/components/ui/`. Each component follows a consistent pattern:
+## Components and the `ui` helper
 
-- **Ruby Component Class** (`component.rb`) - Server-side logic and HTML generation
-- **CSS Styles** (`component.css`) - Component-specific styles
-- **Stimulus Controller** (`component_controller.js`) - Client-side behavior when needed
-- **ERB Template** (`component.html.erb`) - HTML structure for complex components
+UI components live in `app/components/ui/<name>/`. The main class is `Ui::<Name>::Component`; slot/subcomponents are nested `*Component` classes in the same folder (e.g. `Ui::Card::HeaderComponent` in `app/components/ui/card/header_component.rb`). Base class is `ApplicationComponent` (`app/components/application_component.rb`), which extends `ViewComponent::Base` and includes `Turbo::FramesHelper`.
 
-#### Component Architecture
-- **Base Class**: `ApplicationComponent` - Inherits from `ViewComponent::Base`
-- **Namespace**: All UI components are under `Ui::` module
-- **Pattern**: Each component supports variants, sizes, and modifiers through CSS classes
-- **Styling**: Uses TailwindCSS utility classes with component-specific CSS for complex styling
+Components are rendered via the `ui` helper (`app/helpers/ui_helper.rb`). The helper resolves names by trying:
 
-#### Available Components
-- **Navigation**: navbar, breadcrumbs, tabs, accordion
-- **Forms**: btn, group, form controls with Stimulus integration
-- **Layout**: card, drawer, modal, table, header, empty
-- **Feedback**: alert, flash, tooltip, popover, spinner
-- **Data**: table with pagination (pagy), clipboard
-- **Interactive**: dropdown, turbo_confirm
+1. `Ui::<helper.camelize>::Component` (e.g. `ui.btn` → `Ui::Btn::Component`, `ui.turbo_confirm` → `Ui::TurboConfirm::Component`)
+2. Falling back to `Ui::<first_part>::<rest>Component` (e.g. `ui.card_header` → `Ui::Card::HeaderComponent`)
 
-### Frontend Structure
-- **Assets**: `app/assets/` contains Stimulus controllers, stylesheets, and images
-- **Entry Points**: `app/assets/entrypoints/` for Vite entry files
-- **Controllers**: `app/assets/controllers/` for Stimulus controllers
-- **Utilities**: `app/assets/utils/` for JavaScript utilities
+When adding a helper name, **match this resolution order** — pick a class path one of those forms maps to, otherwise the helper will raise.
 
-### Authentication
-Uses Rodauth for authentication with the following features enabled:
-- User registration and login
-- Password reset functionality
-- Account verification
-- Multi-phase login support
+The first positional `String` arg is treated as block content:
 
-### Development Tools
-- **Component Documentation** - Full component docs at `/ui/components/[name]` (e.g., `/ui/components/btn`)
-- **Letter Opener** - Preview emails in development
-- **Annotate** - Auto-generate model schema annotations
-
-### Component Documentation System
-Each component has a `component.yml` file with full API documentation:
-
-```yaml
-# app/components/ui/[name]/component.yml
-name: Component Name
-description: What it does
-props:
-  - name: variant
-    type: Symbol
-    default: ":default"
-    options: ":default, :outline, :secondary"
-    description: Visual style
-examples:
-  - name: Basic Usage
-    code: |
-      <%= ui.component_name("text", variant: :default) %>
-```
-
-Documentation URLs:
-- Components: `/ui/components/[name]` (btn, alert, card, etc.)
-- Forms: `/ui/forms/[name]` (text_field, text_area, select, etc.)
-
-## File Organization
-
-### Component Structure
-```
-app/components/ui/[component_name]/
-├── component.rb          # Main component class
-├── component.html.erb    # Template (if needed)
-├── component.css         # Styles
-├── component_controller.js # Stimulus controller (if needed)
-└── [nested_components]/  # Sub-components
-```
-
-### Asset Structure
-```
-app/assets/
-├── controllers/          # Stimulus controllers
-├── entrypoints/         # Vite entry points
-├── stylesheets/         # CSS files and component styles
-├── images/              # Static images and icons
-└── utils/               # JavaScript utilities
-```
-
-## Testing and Quality
-
-### Testing Framework
-- Uses Rails default testing framework
-- Component previews available through Lookbook
-- Factory Bot for test data generation
-
-### Code Quality Tools
-- **RuboCop** with Rails Omakase configuration
-- **ERB Lint** for template linting
-- **StandardJS** for JavaScript linting
-- **Brakeman** for security scanning
-- **Bundler Audit** for dependency vulnerability scanning
-
-## Development Workflow
-
-1. **Component Development**: Create new UI components in `app/components/ui/` following the established pattern
-2. **Styling**: Use TailwindCSS utilities with component-specific CSS when needed
-3. **JavaScript**: Add Stimulus controllers for interactive behavior
-4. **Previews**: Use Lookbook for component development and testing
-5. **Quality**: Run linting and security tools before committing
-
-## Key Patterns
-
-### Component Initialization
-Components typically accept configuration options like `variant`, `size`, `url`, and boolean modifiers:
-```ruby
-def initialize(variant: nil, size: :md, url: nil, **options)
-```
-
-### CSS Class Management
-Uses Rails' `class_names` helper to conditionally apply CSS classes based on component state and options.
-
-### Using the `ui` Helper
-Components can be rendered using the `ui` helper for a cleaner syntax:
 ```erb
-<%= ui.btn("Click me", variant: :default, url: "/path") %>
-<%= ui.badge("Status", variant: :success) %>
+<%= ui.btn("Click me", variant: :default) %>
 <%= ui.alert(title: "Warning", variant: :warning) { "Message" } %>
-```
-
-### Rendering Complex Components
-Complex components with subcomponents also use the `ui` helper:
-```erb
 <%= ui.card do %>
-  <%= ui.card_header(justify: :between) do %>
-    <%= ui.card_title("Title") %>
-  <% end %>
-  <%= ui.card_body do %>
-    Content
-  <% end %>
+  <%= ui.card_header { ui.card_title("Title") } %>
+  <%= ui.card_body { "Content" } %>
 <% end %>
 ```
 
-#### Header Component (Page Header)
-```erb
-<%= ui.header(sticky: true, bordered: true) do %>
-  <%= ui.header_heading do %>
-    <%= ui.header_title("Page Title") %>
-    <%= ui.header_subtitle("Subtitle") %>
-  <% end %>
-  <%= ui.header_actions do %>
-    <%= ui.btn("Action", variant: :default) %>
-  <% end %>
-<% end %>
+### Per-component file layout
+
+```
+app/components/ui/<name>/
+├── component.rb              # main class (Ui::<Name>::Component)
+├── component.html.erb        # template (only if needed; many use call/content_tag)
+├── component.css             # styles, auto-imported
+├── component_controller.js   # Stimulus controller (if interactive)
+├── component.yml             # docs metadata (props, slots, examples)
+└── <slot>_component.rb       # nested slot/subcomponent classes
 ```
 
-#### Empty State Component
-```erb
-<%= ui.empty do %>
-  <%= ui.empty_icon(name: "user") %>
-  <%= ui.empty_title("No items") %>
-  <%= ui.empty_description("Description text") %>
-  <%= ui.empty_actions do %>
-    <%= ui.btn("Create", variant: :default) %>
-  <% end %>
-<% end %>
-```
+Component JS/CSS under `app/components/**/*.{js,css}` is **auto-imported** by `app/assets/entrypoints/application.js` via `import.meta.glob(..., { eager: true })`. Put component-specific assets next to the component — do not add manual imports.
 
-## Custom Agents
+## Documentation pages
 
-### Frontend Agent
-For creating pages and views using existing UI components, use the frontend agent:
-- Location: `.claude/agents/frontend.md`
-- Purpose: Create pages without writing new CSS, using only existing components
-- Documentation: Full component API reference in `component.yml` files
+Documentation pages are **not** generated automatically from routes or `component.yml`. To document a new component you typically need:
 
-## Adding Component Documentation
+1. The component folder under `app/components/ui/<name>/` with `component.yml`.
+2. An explicit route in `config/routes.rb` under `namespace :ui`.
+3. A view at `app/views/ui/<name>.html.erb` that calls `render_component_*` helpers from `ComponentDocsHelper` (`app/helpers/component_docs_helper.rb`).
 
-To add or update component documentation:
+`component.yml` examples and previews are rendered as **inline ERB** by `ComponentDocsHelper` — keep snippets executable, not pseudocode. Form-builder docs are loaded from `app/components/form_builders/<name>/component.yml` even though the Ruby code lives under `app/lib/form_builders/`.
 
-1. Create/edit `app/components/ui/[name]/component.yml`:
+`component.yml` shape:
+
 ```yaml
 name: ComponentName
 description: Brief description
@@ -218,12 +80,35 @@ props:
   - name: variant
     type: Symbol
     default: ":default"
-    options: ":default, :outline"
+    values: [":default", ":outline"]
     description: What it controls
+slots:
+  - name: card_header
+    description: Header slot
 examples:
   - name: Basic
     code: |
       <%= ui.component_name("text") %>
 ```
 
-2. Access documentation at `/ui/components/[name]` or `/ui/forms/[name]`
+## Form builders
+
+The default `form_with` is wired in `app/helpers/application_helper.rb` to use `FormBuilders::DefaultFormBuilder` and add a default `form` class. Custom field implementations live in `app/lib/form_builders/fields/` (text, select, choices, easepick, toggler, check_box, radio_button, etc.). Form-builder docs live alongside `app/components/form_builders/<name>/component.yml`.
+
+## Frontend gotchas
+
+- Vite source root is `app/assets` (`config/vite.json`). JS imports use the `~` alias for paths under `app/assets`.
+- **Tailwind CSS 4** is configured in CSS, not `tailwind.config.js`: see `app/assets/entrypoints/tailwind.css`, `app/assets/stylesheets/tailwind/*`, and `tailwindcss_safelist.txt`.
+- Stimulus controllers under `app/assets/controllers/**/*_controller.js` and component controllers are eagerly imported, but each controller registers itself with `stimulus.register(...)`. Follow that pattern for new controllers.
+
+## Auth
+
+Uses Rodauth (`rodauth-rails` + `rodauth-omniauth`). Authenticated routes are wrapped in `constraints Rodauth::Rails.authenticate do ... end` in `config/routes.rb`.
+
+## Deploy
+
+Production deploy is Kamal via `.github/workflows/01.deploy_production.yaml` and `config/deploy.yml`. Image build uses `asset_path: /rails/public/vite/assets` and secrets `RAILS_MASTER_KEY`, `KAMAL_REGISTRY_USERNAME`, `KAMAL_REGISTRY_PASSWORD`.
+
+## Custom agents
+
+`.claude/agents/frontend.md` — for building pages from existing UI components without writing new CSS. Use the per-component `component.yml` files as the API reference.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,8 @@ Components are rendered via the `ui` helper (`app/helpers/ui_helper.rb`). The he
 
 When adding a helper name, **match this resolution order** — pick a class path one of those forms maps to, otherwise the helper will raise.
 
+When authoring a component, follow the existing convention: build the class list with Rails' `class_names` helper, and accept `variant:`, `size:`, `url:`, and boolean modifiers, merging any caller-supplied `class:` (e.g. `Ui::Btn::Component` in `app/components/ui/btn/component.rb`).
+
 The first positional `String` arg is treated as block content:
 
 ```erb

--- a/README.md
+++ b/README.md
@@ -1,16 +1,15 @@
 # Rails UI Component Library
 
-A comprehensive Rails 7 component library built with ViewComponent, TailwindCSS 4.0, and Stimulus. This template provides a complete set of reusable UI components that developers can copy and customize for their projects.
+A comprehensive Rails 8 component library built with ViewComponent, TailwindCSS 4.0, and Stimulus. This template provides a complete set of reusable UI components that developers can copy and customize for their projects.
 
 ## 🚀 Quick Start
 
 ### Requirements
 
-- **Ruby** 3.4.4+
-- **Rails** 7.0+
-- **Node.js** 18+
-- **ViewComponent** gem
-- **TailwindCSS** 4.0
+- **Ruby** 3.4+
+- **Rails** 8.1+
+- **Node.js** 22+
+- **Yarn** Classic
 
 ### Installation
 
@@ -71,7 +70,7 @@ end
 Components are namespaced under the `Ui::` module:
 
 ```ruby
-class Ui::Button::Component < ApplicationComponent
+class Ui::Btn::Component < ApplicationComponent
   def initialize(variant: :default, size: :md, **options)
     @variant = variant
     @size = size
@@ -198,29 +197,10 @@ bundle exec erb_lint         # ERB template linting
 
 ```
 app/
-├── components/ui/           # UI Components library
-│   ├── accordion/          # Accordion component
-│   ├── alert/              # Alert component
-│   ├── avatar/             # Avatar component
-│   ├── badge/              # Badge component
-│   ├── btn/                # Button component
-│   ├── card/               # Card component with sub-components
-│   ├── clipboard/          # Clipboard component
-│   ├── drawer/             # Drawer component
-│   ├── dropdown/           # Dropdown component with sub-components
-│   ├── empty/              # Empty state component with sub-components
-│   ├── flash/              # Flash message component
-│   ├── group/              # Button group component
-│   ├── header/             # Page header component with sub-components
-│   ├── icon/               # Icon component
-│   ├── modal/              # Modal component
-│   ├── pagy/               # Pagination component
-│   ├── popover/            # Popover component with sub-components
-│   ├── spinner/            # Loading spinner component
-│   ├── table/              # Table component with sub-components
-│   ├── tabs/               # Tabs component
-│   ├── tooltip/            # Tooltip component
-│   └── turbo_confirm/      # Turbo confirmation component
+├── components/ui/           # UI component library (one folder per component)
+│   ├── btn/                # Each component: component.rb, component.css,
+│   ├── card/               # component.yml, plus *_component.rb sub-components
+│   └── .../                # and component_controller.js when interactive
 ├── assets/
 │   ├── controllers/        # Stimulus controllers
 │   ├── entrypoints/        # Vite entry points
@@ -229,9 +209,11 @@ app/
     └── layouts/            # Application layouts
 ```
 
+Browse `app/components/ui/` for the full set of components, or see the live docs under `/ui`.
+
 ## 🎯 Key Technologies
 
-- **Rails 8.0** - Backend framework with modern features
+- **Rails 8.1** - Backend framework with modern features
 - **ViewComponent** - Component-based architecture for views
 - **Vite** - Fast build tool for frontend assets
 - **TailwindCSS 4.0** - Utility-first CSS framework


### PR DESCRIPTION
## Why

The repo's docs had drifted from the actual code on runtime versions, commands that don't do what they claim, and references to tooling that isn't present. This refreshes the agent/developer-facing docs and makes them resistant to going stale again.

## Changes

**CLAUDE.md** — rewritten to match reality:
- Point to source-of-truth files (`.ruby-version`, `Gemfile`, `.node-version`, `package.json`) for runtime versions instead of pinning them inline
- Correct command docs: `bin/dev` only starts Rails (not Vite); Vite runs separately on port 3036
- Document the actual `ui` helper resolution order (`Ui::<Name>::Component`, then `Ui::<First>::<Rest>Component`)
- Note component JS/CSS auto-import, the docs-page wiring, and the form-builder Ruby/docs split
- Drop claims about a test framework and Lookbook — neither exists in this repo

**AGENTS.md** — new self-contained agent guide covering commands, app shape, the component/`ui` helper model, and frontend gotchas

**README.md**:
- Title and Key Technologies: Rails 7 → Rails 8
- Requirements floors corrected (Ruby 3.4+, Rails 8.1+, Node 22+, Yarn Classic)
- Fix architecture example: `Ui::Button::Component` → `Ui::Btn::Component`
- Replace the hand-maintained component list (already missing 7 components) with a representative structure + pointer to `app/components/ui/` and the `/ui` docs

## Notes

Docs-only change. No code or behavior affected.