### PR TITLE
Add LLM-native documentation endpoints

### DIFF
--- a/app/controllers/llms_controller.rb
+++ b/app/controllers/llms_controller.rb
@@ -8,27 +8,30 @@
 # power the human docs (see ComponentCatalog / ComponentMarkdown), so it
 # can never drift and needs no build step.
 class LlmsController < ApplicationController
+  MARKDOWN = "text/markdown; charset=utf-8".freeze
+
   def index
-    render plain: index_document, content_type: "text/markdown"
+    render plain: index_document, content_type: MARKDOWN
   end
 
   def full
-    render plain: full_document, content_type: "text/markdown"
+    render plain: full_document, content_type: MARKDOWN
   end
 
   def component
     entry = ComponentCatalog.find(params[:name])
     return head(:not_found) unless entry
 
-    render plain: ComponentMarkdown.call(entry), content_type: "text/markdown"
+    render plain: ComponentMarkdown.call(entry), content_type: MARKDOWN
   end
 
   private
 
   def index_document
+    entries = ComponentCatalog.all
     sections = {
-      "Components" => ComponentCatalog.components,
-      "Form Builders" => ComponentCatalog.forms
+      "Components" => entries.select(&:component?),
+      "Form Builders" => entries.reject(&:component?)
     }
 
     out = [
@@ -36,7 +39,7 @@ class LlmsController < ApplicationController
       "",
       "A Rails ViewComponent library. Render components with the `ui` helper, " \
         "e.g. `<%= ui.btn(\"Save\", variant: :default) %>`. " \
-        "Fetch #{full_url} for the complete API in one document."
+        "Fetch #{llms_full_url} for the complete API in one document."
     ]
 
     sections.each do |title, entries|
@@ -44,7 +47,8 @@ class LlmsController < ApplicationController
 
       out << "" << "## #{title}" << ""
       entries.each do |entry|
-        out << "- [#{entry.title}](#{component_url(entry)}): #{entry.description}"
+        url = llms_component_url(name: entry.name, format: :md)
+        out << "- [#{entry.title}](#{url}): #{entry.description}"
       end
     end
 
@@ -61,13 +65,5 @@ class LlmsController < ApplicationController
 
     body = ComponentCatalog.all.map { |entry| ComponentMarkdown.call(entry) }
     header + "\n" + body.join("\n---\n\n")
-  end
-
-  def component_url(entry)
-    "#{request.base_url}/ui/components/#{entry.name}.md"
-  end
-
-  def full_url
-    "#{request.base_url}/llms-full.txt"
   end
 end

--- a/app/controllers/llms_controller.rb
+++ b/app/controllers/llms_controller.rb
@@ -19,6 +19,10 @@ class LlmsController < ApplicationController
   end
 
   def component
+    # The route's format constraint still admits extensionless URLs, so
+    # enforce the documented `.md` contract here.
+    return head(:not_found) unless params[:format] == "md"
+
     entry = ComponentCatalog.find(params[:name])
     return head(:not_found) unless entry
 

--- a/app/controllers/llms_controller.rb
+++ b/app/controllers/llms_controller.rb
@@ -1,0 +1,73 @@
+# LLM-native documentation surface.
+#
+#   GET /llms.txt                 → curated index (links to per-component markdown)
+#   GET /llms-full.txt            → entire component corpus inlined, single fetch
+#   GET /ui/components/:name.md   → one component as plain markdown
+#
+# All output is generated live from the same `component.yml` files that
+# power the human docs (see ComponentCatalog / ComponentMarkdown), so it
+# can never drift and needs no build step.
+class LlmsController < ApplicationController
+  def index
+    render plain: index_document, content_type: "text/markdown"
+  end
+
+  def full
+    render plain: full_document, content_type: "text/markdown"
+  end
+
+  def component
+    entry = ComponentCatalog.find(params[:name])
+    return head(:not_found) unless entry
+
+    render plain: ComponentMarkdown.call(entry), content_type: "text/markdown"
+  end
+
+  private
+
+  def index_document
+    sections = {
+      "Components" => ComponentCatalog.components,
+      "Form Builders" => ComponentCatalog.forms
+    }
+
+    out = [
+      "# JetRockets UI",
+      "",
+      "A Rails ViewComponent library. Render components with the `ui` helper, " \
+        "e.g. `<%= ui.btn(\"Save\", variant: :default) %>`. " \
+        "Fetch #{full_url} for the complete API in one document."
+    ]
+
+    sections.each do |title, entries|
+      next if entries.empty?
+
+      out << "" << "## #{title}" << ""
+      entries.each do |entry|
+        out << "- [#{entry.title}](#{component_url(entry)}): #{entry.description}"
+      end
+    end
+
+    out.join("\n") + "\n"
+  end
+
+  def full_document
+    header = [
+      "# JetRockets UI — Full Reference",
+      "",
+      "Rails ViewComponent library. Render with the `ui` helper.",
+      ""
+    ].join("\n")
+
+    body = ComponentCatalog.all.map { |entry| ComponentMarkdown.call(entry) }
+    header + "\n" + body.join("\n---\n\n")
+  end
+
+  def component_url(entry)
+    "#{request.base_url}/ui/components/#{entry.name}.md"
+  end
+
+  def full_url
+    "#{request.base_url}/llms-full.txt"
+  end
+end

--- a/app/services/component_catalog.rb
+++ b/app/services/component_catalog.rb
@@ -1,0 +1,41 @@
+# Single source of truth for LLM-facing docs.
+#
+# Scans the same `component.yml` files that power the human docs
+# (rendered by ComponentDocsHelper), so the llms.txt / *.md output can
+# never drift from the website — there is nothing extra to regenerate.
+class ComponentCatalog
+  SOURCES = [
+    { category: :component, root: "app/components/ui" },
+    { category: :form,      root: "app/components/form_builders" }
+  ].freeze
+
+  Entry = Struct.new(:name, :category, :data, keyword_init: true) do
+    def title       = data["name"].presence || name.humanize
+    def description = data["description"].to_s.strip
+    def component?  = category == :component
+  end
+
+  class << self
+    def all
+      SOURCES.flat_map { |src| load_source(src) }.sort_by(&:name)
+    end
+
+    def components = all.select(&:component?)
+    def forms      = all.reject(&:component?)
+
+    def find(name)
+      all.find { |e| e.name == name.to_s }
+    end
+
+    private
+
+    def load_source(src)
+      Dir.glob(Rails.root.join(src[:root], "*/component.yml")).filter_map do |path|
+        data = YAML.safe_load(File.read(path))
+        next if data.blank?
+
+        Entry.new(name: File.basename(File.dirname(path)), category: src[:category], data: data)
+      end
+    end
+  end
+end

--- a/app/services/component_catalog.rb
+++ b/app/services/component_catalog.rb
@@ -31,11 +31,20 @@ class ComponentCatalog
 
     def load_source(src)
       Dir.glob(Rails.root.join(src[:root], "*/component.yml")).filter_map do |path|
-        data = YAML.safe_load(File.read(path))
+        data = load_yaml(path)
         next if data.blank?
 
         Entry.new(name: File.basename(File.dirname(path)), category: src[:category], data: data)
       end
+    end
+
+    # A syntax error in one component.yml must not take down the whole
+    # corpus endpoint — skip the bad file and keep serving the rest.
+    def load_yaml(path)
+      YAML.safe_load(File.read(path))
+    rescue Psych::SyntaxError => e
+      Rails.logger.warn("[ComponentCatalog] skipping #{path}: #{e.message}")
+      nil
     end
   end
 end

--- a/app/services/component_markdown.rb
+++ b/app/services/component_markdown.rb
@@ -1,0 +1,96 @@
+# Renders one ComponentCatalog::Entry to plain Markdown.
+#
+# This is the LLM-native mirror of ComponentDocsHelper's HTML output:
+# same data (props, slots, usage, examples), flat Markdown instead of
+# ViewComponent markup.
+class ComponentMarkdown
+  def initialize(entry)
+    @entry = entry
+    @data  = entry.data
+  end
+
+  def self.call(entry) = new(entry).call
+
+  def call
+    [
+      heading,
+      usage_section,
+      props_section,
+      slots_section,
+      examples_section
+    ].compact.join("\n\n") + "\n"
+  end
+
+  private
+
+  attr_reader :entry, :data
+
+  def heading
+    out = ["# #{entry.title}"]
+    out << entry.description if entry.description.present?
+    out.join("\n\n")
+  end
+
+  def usage_section
+    usage = data["usage"].presence || data["preview"].presence
+    return if usage.blank?
+
+    "## Usage\n\n#{erb_block(usage)}"
+  end
+
+  def props_section
+    props = Array(data["props"])
+    return if props.empty?
+
+    rows = props.map do |prop|
+      type = [prop["type"], format_values(prop["values"])].compact.join(" ")
+      "| `#{prop['name']}` | #{type} | #{code_or_dash(prop['default'])} | #{inline(prop['description'])} |"
+    end
+
+    table = ["| Prop | Type | Default | Description |", "|------|------|---------|-------------|", *rows].join("\n")
+    note  = data["accepts_html_attributes"] ? "\n\nAlso accepts any HTML attributes via `**options` (e.g. `id:`, `data:`, `aria:`, `class:`)." : ""
+
+    "## Props\n\n#{table}#{note}"
+  end
+
+  def slots_section
+    slots = Array(data["slots"])
+    return if slots.empty?
+
+    rows = slots.map do |slot|
+      "| `#{slot['name']}` | `ui.#{slot['name']}` | #{inline(slot['description'])} |"
+    end
+
+    table = ["| Name | Helper | Description |", "|------|--------|-------------|", *rows].join("\n")
+    "## Subcomponents\n\nUse the subcomponents below, or any HTML.\n\n#{table}"
+  end
+
+  def examples_section
+    examples = Array(data["examples"])
+    return if examples.empty?
+
+    blocks = examples.map do |ex|
+      "### #{ex['name']}\n\n#{erb_block(ex['code'])}"
+    end
+
+    "## Examples\n\n#{blocks.join("\n\n")}"
+  end
+
+  def erb_block(code)
+    "```erb\n#{code.to_s.strip}\n```"
+  end
+
+  def format_values(values)
+    return if values.blank?
+
+    "(#{Array(values).join(', ')})"
+  end
+
+  def code_or_dash(value)
+    value.present? ? "`#{value}`" : "—"
+  end
+
+  def inline(text)
+    text.to_s.gsub(/\s+/, " ").strip
+  end
+end

--- a/app/services/component_markdown.rb
+++ b/app/services/component_markdown.rb
@@ -39,17 +39,10 @@ class ComponentMarkdown
   end
 
   def props_section
-    props = Array(data["props"])
-    return if props.empty?
+    table = props_table(Array(data["props"]))
+    return if table.nil?
 
-    rows = props.map do |prop|
-      type = [prop["type"], format_values(prop["values"])].compact.join(" ")
-      "| `#{prop['name']}` | #{type} | #{code_or_dash(prop['default'])} | #{inline(prop['description'])} |"
-    end
-
-    table = ["| Prop | Type | Default | Description |", "|------|------|---------|-------------|", *rows].join("\n")
-    note  = data["accepts_html_attributes"] ? "\n\nAlso accepts any HTML attributes via `**options` (e.g. `id:`, `data:`, `aria:`, `class:`)." : ""
-
+    note = data["accepts_html_attributes"] ? "\n\nAlso accepts any HTML attributes via `**options` (e.g. `id:`, `data:`, `aria:`, `class:`)." : ""
     "## Props\n\n#{table}#{note}"
   end
 
@@ -57,12 +50,29 @@ class ComponentMarkdown
     slots = Array(data["slots"])
     return if slots.empty?
 
-    rows = slots.map do |slot|
-      "| `#{slot['name']}` | `ui.#{slot['name']}` | #{inline(slot['description'])} |"
+    blocks = slots.map do |slot|
+      parts = ["### `ui.#{slot['name']}`"]
+      parts << inline(slot["description"]) if slot["description"].present?
+      props_table = props_table(Array(slot["props"]))
+      parts << props_table if props_table
+      parts.join("\n\n")
     end
 
-    table = ["| Name | Helper | Description |", "|------|--------|-------------|", *rows].join("\n")
-    "## Subcomponents\n\nUse the subcomponents below, or any HTML.\n\n#{table}"
+    "## Subcomponents\n\nUse the subcomponents below, or any HTML.\n\n#{blocks.join("\n\n")}"
+  end
+
+  # Shared by the top-level Props section and each subcomponent's props,
+  # so pipe-escaping and column layout stay consistent. Returns nil when
+  # there are no props.
+  def props_table(props)
+    return if props.empty?
+
+    rows = props.map do |prop|
+      type = [prop["type"], format_values(prop["values"])].compact.join(" ")
+      "| #{code_cell(prop['name'])} | #{cell(type)} | #{code_cell(prop['default'])} | #{cell(prop['description'])} |"
+    end
+
+    ["| Prop | Type | Default | Description |", "|------|------|---------|-------------|", *rows].join("\n")
   end
 
   def examples_section
@@ -86,8 +96,15 @@ class ComponentMarkdown
     "(#{Array(values).join(', ')})"
   end
 
-  def code_or_dash(value)
-    value.present? ? "`#{value}`" : "—"
+  # A plain table cell: single line, pipes escaped so they don't spawn
+  # extra columns (e.g. a type of "String | false").
+  def cell(text)
+    inline(text).gsub("|", "\\|")
+  end
+
+  # A code-formatted table cell, or an em dash when blank.
+  def code_cell(value)
+    value.present? ? "`#{cell(value)}`" : "—"
   end
 
   def inline(text)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,11 @@ Rails.application.routes.draw do
   get "ui", to: "ui#index"
   get "builder", to: "builder#index"
   get "builder/download", to: "builder#download"
+
+  # LLM-native documentation (generated live from component.yml files)
+  get "llms.txt", to: "llms#index", as: :llms, format: false
+  get "llms-full.txt", to: "llms#full", as: :llms_full, format: false
+  get "ui/components/:name", to: "llms#component", as: :llms_component, format: "md", constraints: { format: "md" }
   # UI Documentation routes
   namespace :ui do
     get "getting_started"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,8 @@ Rails.application.routes.draw do
   # LLM-native documentation (generated live from component.yml files)
   get "llms.txt", to: "llms#index", as: :llms, format: false
   get "llms-full.txt", to: "llms#full", as: :llms_full, format: false
-  get "ui/components/:name", to: "llms#component", as: :llms_component, format: "md", constraints: { format: "md" }
+  get "ui/components/:name", to: "llms#component", as: :llms_component, constraints: { format: "md" }
+
   # UI Documentation routes
   namespace :ui do
     get "getting_started"


### PR DESCRIPTION
## What

Exposes the component library docs in a format coding agents (Claude Code, Codex, opencode) can consume directly — without scraping the HTML site.

| Endpoint | Purpose |
|---|---|
| `GET /llms.txt` | Curated markdown index, one line per component, linking to each `.md` |
| `GET /llms-full.txt` | Entire component corpus inlined — point an agent here for the whole API in one fetch |
| `GET /ui/components/:name.md` | A single component as plain markdown (`btn`, `tabs`, `text_area`, …) |

Follows the emerging `llms.txt` convention (Stripe, Vercel, Cloudflare, shadcn).

## How

All output is generated **live** from the same `component.yml` files that power the human docs — so there is no second source to maintain and the output can't drift.

- `ComponentCatalog` — scans `app/components/ui/*` and `app/components/form_builders/*` for `component.yml`
- `ComponentMarkdown` — renders one entry to Markdown (description, usage, props table, subcomponents, examples); the LLM mirror of `ComponentDocsHelper`
- `LlmsController` — serves the three endpoints as `text/markdown`

Per-component URLs are keyed off the component **directory name** (`btn`, not `button`) to match the `ui` helper identifier agents would actually write.

## Notes

No new dependencies.